### PR TITLE
Max tick cross test

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -350,7 +350,7 @@ export async function initSwap(
       approvedAmount
     },
     tokens: [{ id, amount: approvedAmount }],
-    attoAlphAmount: DUST_AMOUNT
+    attoAlphAmount: DUST_AMOUNT * 2n
   })
 }
 

--- a/test/max_tick_cross.test.ts
+++ b/test/max_tick_cross.test.ts
@@ -316,4 +316,333 @@ describe('max tick cross spec', () => {
     expect(crosses).toBe(1792n)
     expect(gasAmount).toBeGreaterThan(txGasLimit)
   }, 100000)
+  test('max tick cross swap xToY and ByAmountOut, no liquidity gap between positions', async () => {
+    const lastInitializedTick = -250n
+    const mintAmount = 60000n
+    const swapAmount = 44500n
+    const xToY = true
+    const slippage = MinSqrtPrice
+    const byAmountIn = false
+
+    for (let i = lastInitializedTick; i < 0n; i += 10n) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenX, mintAmount])
+
+    const { targetSqrtPrice } = await quote(
+      invariant,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      slippage
+    )
+
+    const poolBefore = await getPool(invariant, poolKey)
+
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      targetSqrtPrice,
+      mintAmount
+    )
+    const poolAfter = await getPool(invariant, poolKey)
+
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
+    expect(crosses).toBe(9n)
+    expect(gasAmount).toBeGreaterThan(txGasLimit)
+  }, 100000)
+  test('max tick cross swap yToX and ByAmountOut, no liquidity gap between positions', async () => {
+    const lastInitializedTick = 120n
+    const mintAmount = 60000n
+    const swapAmount = 39000n
+
+    const xToY = false
+    const slippage = MaxSqrtPrice
+    const byAmountIn = false
+
+    for (let i = 0n; i < lastInitializedTick; i += 10n) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenY, mintAmount])
+
+    const { targetSqrtPrice } = await quote(
+      invariant,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      slippage
+    )
+
+    const poolBefore = await getPool(invariant, poolKey)
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      targetSqrtPrice,
+      mintAmount
+    )
+
+    const poolAfter = await getPool(invariant, poolKey)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
+    expect(crosses).toBe(7n)
+    expect(gasAmount).toBeGreaterThan(txGasLimit)
+  }, 100000)
+  test('max tick cross swap xToY and ByAmountOut, liquidity gap between positions', async () => {
+    const lastInitializedTick = -500n
+    const mintAmount = 60000n
+    const swapAmount = 39500n
+    const xToY = true
+    const slippage = MinSqrtPrice
+    const byAmountIn = false
+
+    for (let i = lastInitializedTick; i < 0n; i += 20n) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenX, mintAmount])
+
+    const { targetSqrtPrice } = await quote(
+      invariant,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      slippage
+    )
+
+    const poolBefore = await getPool(invariant, poolKey)
+
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      targetSqrtPrice,
+      mintAmount
+    )
+    const poolAfter = await getPool(invariant, poolKey)
+
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
+    expect(crosses).toBe(16n)
+    expect(gasAmount).toBeGreaterThan(txGasLimit)
+  }, 100000)
+  test('max tick cross swap yToX and ByAmountOut, liquidity gap between positions', async () => {
+    const lastInitializedTick = 360n
+    const mintAmount = 60000n
+    const swapAmount = 39000n
+
+    const xToY = false
+    const slippage = MaxSqrtPrice
+    const byAmountIn = false
+
+    for (let i = 0n; i < lastInitializedTick; i += 20n) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenY, mintAmount])
+
+    const { targetSqrtPrice } = await quote(
+      invariant,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      slippage
+    )
+
+    const poolBefore = await getPool(invariant, poolKey)
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      targetSqrtPrice,
+      mintAmount
+    )
+
+    const poolAfter = await getPool(invariant, poolKey)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
+    expect(crosses).toBe(14n)
+    expect(gasAmount).toBeGreaterThan(txGasLimit)
+  }, 100000)
+  test('max tick cross swap xToY and ByAmountOut, positions between search limit range', async () => {
+    const lastInitializedTick = -25000n
+    const mintAmount = 80000n
+    const swapAmount = 24000n
+    const xToY = true
+    const slippage = MinSqrtPrice
+    const byAmountIn = false
+
+    for (let i = lastInitializedTick; i < 0n; i += searchLimit) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenX, mintAmount])
+
+    const { targetSqrtPrice } = await quote(
+      invariant,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      slippage
+    )
+
+    const poolBefore = await getPool(invariant, poolKey)
+
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      targetSqrtPrice,
+      mintAmount
+    )
+    const poolAfter = await getPool(invariant, poolKey)
+
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
+    expect(crosses).toBe(1988n)
+    expect(gasAmount).toBeGreaterThan(txGasLimit)
+  }, 100000)
+  test('max tick cross swap yToX and ByAmountOut, positions between search limit range', async () => {
+    const lastInitializedTick = 25000n
+    const mintAmount = 80000n
+    const swapAmount = 24500n
+    const xToY = false
+    const slippage = MaxSqrtPrice
+    const byAmountIn = false
+
+    for (let i = 0n; i < lastInitializedTick; i += searchLimit) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenY, mintAmount])
+
+    const { targetSqrtPrice } = await quote(
+      invariant,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      slippage
+    )
+
+    const poolBefore = await getPool(invariant, poolKey)
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      xToY,
+      swapAmount,
+      byAmountIn,
+      targetSqrtPrice,
+      mintAmount
+    )
+
+    const poolAfter = await getPool(invariant, poolKey)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
+    expect(crosses).toBe(1536n)
+    expect(gasAmount).toBeGreaterThan(txGasLimit)
+  }, 100000)
 })

--- a/test/max_tick_cross.test.ts
+++ b/test/max_tick_cross.test.ts
@@ -1,0 +1,91 @@
+import { ONE_ALPH, web3 } from '@alephium/web3'
+import { getSigner } from '@alephium/web3-test'
+import { PrivateKeyWallet } from '@alephium/web3-wallet'
+import { balanceOf, deployInvariant, newFeeTier, newPoolKey } from '../src/utils'
+import {
+  getBasicFeeTickSpacing,
+  initBasicPool,
+  initBasicPosition,
+  initBasicSwap,
+  initDexAndTokens
+} from '../src/snippets'
+import {
+  getPool,
+  initFeeTier,
+  initPosition,
+  initSwap,
+  initTokensXY,
+  quote,
+  withdrawTokens
+} from '../src/testUtils'
+import { LiquidityScale, MinSqrtPrice } from '../src/consts'
+
+web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+
+describe('max tick cross spec', () => {
+  test('max tick cross', async () => {
+    const admin = await getSigner(ONE_ALPH * 1000n, 0)
+    const positionOwner = await getSigner(ONE_ALPH * 1000n, 0)
+    const swapper = await getSigner(ONE_ALPH * 1000n, 0)
+
+    const [fee, tickSpacing] = getBasicFeeTickSpacing()
+    const positionOwnerMint = 1n << 128n
+    const swapperMint = 1n << 30n
+    const supply = positionOwnerMint + swapperMint
+
+    const invariant = await deployInvariant(admin, 0n)
+    const [tokenX, tokenY] = await initTokensXY(admin, supply)
+    await withdrawTokens(positionOwner, [tokenX, positionOwnerMint], [tokenY, positionOwnerMint])
+
+    const feeTier = await newFeeTier(fee, tickSpacing)
+    await initFeeTier(invariant, admin, feeTier)
+    await initBasicPool(invariant, admin, tokenX, tokenY)
+    const poolKey = await newPoolKey(tokenX.contractId, tokenY.contractId, feeTier)
+    const liquidityDelta = 10000000n * 10n ** LiquidityScale
+
+    const lastTick = -250n
+    const amount = 40300n
+    // 40.3k - 8
+    // 40.4k - out of gas
+
+    for (let i = lastTick; i < 0n; i += 10n) {
+      const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
+      const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
+      const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)
+      await initPosition(
+        invariant,
+        positionOwner,
+        poolKey,
+        positionOwnerBalanceX,
+        positionOwnerBalanceY,
+        i,
+        i + 10n,
+        liquidityDelta,
+        slippageLimit,
+        slippageLimit
+      )
+    }
+
+    await withdrawTokens(swapper, [tokenX, amount])
+
+    const slippage = MinSqrtPrice
+
+    const { targetSqrtPrice } = await quote(invariant, poolKey, true, amount, true, slippage)
+
+    const poolBefore = await getPool(invariant, poolKey)
+    const { gasAmount } = await initSwap(
+      invariant,
+      swapper,
+      poolKey,
+      true,
+      amount,
+      true,
+      targetSqrtPrice
+    )
+    const poolAfter = await getPool(invariant, poolKey)
+
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
+    expect(crosses).toBe(8n)
+    expect(gasAmount).toBeGreaterThan(500000n)
+  }, 100000)
+})

--- a/test/max_tick_cross.test.ts
+++ b/test/max_tick_cross.test.ts
@@ -21,7 +21,7 @@ web3.setCurrentNodeProvider('http://127.0.0.1:22973')
 describe('max tick cross spec', () => {
   const [fee, tickSpacing] = getBasicFeeTickSpacing()
   const searchLimit = SearchRange * tickSpacing
-  const txGasLimit = 500000n
+  const txGasLimit = 5000000n
   const positionOwnerMint = 1n << 128n
   const swapperMint = 1n << 30n
   const supply = positionOwnerMint + swapperMint
@@ -91,7 +91,7 @@ describe('max tick cross spec', () => {
 
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
     expect(crosses).toBe(8n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountIn, no liquidity gap between positions', async () => {
     const lastInitializedTick = 120n
@@ -136,7 +136,7 @@ describe('max tick cross spec', () => {
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
     expect(crosses).toBe(8n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap xToY and ByAmountIn, liquidity gap between positions', async () => {
     const lastInitializedTick = -250n
@@ -180,7 +180,7 @@ describe('max tick cross spec', () => {
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
     expect(crosses).toBe(13n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountIn, liquidity gap between positions', async () => {
     const lastInitializedTick = 240n
@@ -225,11 +225,11 @@ describe('max tick cross spec', () => {
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
     expect(crosses).toBe(14n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap xToY and ByAmountIn, positions between search limit range', async () => {
     const lastInitializedTick = -35000n
-    const amount = 58100n
+    const amount = 13570000n
     const xToY = true
     const slippage = MinSqrtPrice
     const byAmountIn = true
@@ -245,7 +245,7 @@ describe('max tick cross spec', () => {
         positionOwnerBalanceX,
         positionOwnerBalanceY,
         i,
-        i + 10n,
+        i + searchLimit,
         liquidityDelta,
         slippageLimit,
         slippageLimit
@@ -269,11 +269,11 @@ describe('max tick cross spec', () => {
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
     expect(crosses).toBe(1708n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountIn, positions between search limit range', async () => {
     const lastInitializedTick = 25000n
-    const amount = 60000n
+    const amount = 17947900n
     const xToY = false
     const slippage = MaxSqrtPrice
     const byAmountIn = true
@@ -289,7 +289,7 @@ describe('max tick cross spec', () => {
         positionOwnerBalanceX,
         positionOwnerBalanceY,
         i,
-        i + 10n,
+        i + searchLimit,
         liquidityDelta,
         slippageLimit,
         slippageLimit
@@ -313,8 +313,8 @@ describe('max tick cross spec', () => {
 
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
-    expect(crosses).toBe(1792n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(crosses).toBe(2047n)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap xToY and ByAmountOut, no liquidity gap between positions', async () => {
     const lastInitializedTick = -250n
@@ -369,7 +369,7 @@ describe('max tick cross spec', () => {
 
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
     expect(crosses).toBe(9n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountOut, no liquidity gap between positions', async () => {
     const lastInitializedTick = 120n
@@ -424,7 +424,7 @@ describe('max tick cross spec', () => {
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
     expect(crosses).toBe(7n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap xToY and ByAmountOut, liquidity gap between positions', async () => {
     const lastInitializedTick = -500n
@@ -479,7 +479,7 @@ describe('max tick cross spec', () => {
 
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
     expect(crosses).toBe(16n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountOut, liquidity gap between positions', async () => {
     const lastInitializedTick = 360n
@@ -534,12 +534,12 @@ describe('max tick cross spec', () => {
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
     expect(crosses).toBe(14n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap xToY and ByAmountOut, positions between search limit range', async () => {
     const lastInitializedTick = -25000n
-    const mintAmount = 80000n
-    const swapAmount = 24000n
+    const mintAmount = 20000000n
+    const swapAmount = 6050000n
     const xToY = true
     const slippage = MinSqrtPrice
     const byAmountIn = false
@@ -555,7 +555,7 @@ describe('max tick cross spec', () => {
         positionOwnerBalanceX,
         positionOwnerBalanceY,
         i,
-        i + 10n,
+        i + searchLimit,
         liquidityDelta,
         slippageLimit,
         slippageLimit
@@ -586,15 +586,14 @@ describe('max tick cross spec', () => {
       mintAmount
     )
     const poolAfter = await getPool(invariant, poolKey)
-
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
-    expect(crosses).toBe(1988n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(crosses).toBe(1858n)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountOut, positions between search limit range', async () => {
     const lastInitializedTick = 25000n
-    const mintAmount = 80000n
-    const swapAmount = 24500n
+    const mintAmount = 20000000n
+    const swapAmount = 6408000n
     const xToY = false
     const slippage = MaxSqrtPrice
     const byAmountIn = false
@@ -610,7 +609,7 @@ describe('max tick cross spec', () => {
         positionOwnerBalanceX,
         positionOwnerBalanceY,
         i,
-        i + 10n,
+        i + searchLimit,
         liquidityDelta,
         slippageLimit,
         slippageLimit
@@ -642,7 +641,7 @@ describe('max tick cross spec', () => {
 
     const poolAfter = await getPool(invariant, poolKey)
     const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
-    expect(crosses).toBe(1536n)
-    expect(gasAmount).toBeGreaterThan(txGasLimit)
+    expect(crosses).toBe(2047n)
+    expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
 })

--- a/test/max_tick_cross.test.ts
+++ b/test/max_tick_cross.test.ts
@@ -1,14 +1,7 @@
 import { ONE_ALPH, web3 } from '@alephium/web3'
 import { getSigner } from '@alephium/web3-test'
-import { PrivateKeyWallet } from '@alephium/web3-wallet'
 import { balanceOf, deployInvariant, newFeeTier, newPoolKey } from '../src/utils'
-import {
-  getBasicFeeTickSpacing,
-  initBasicPool,
-  initBasicPosition,
-  initBasicSwap,
-  initDexAndTokens
-} from '../src/snippets'
+import { getBasicFeeTickSpacing, initBasicPool } from '../src/snippets'
 import {
   getPool,
   initFeeTier,

--- a/test/max_tick_cross.test.ts
+++ b/test/max_tick_cross.test.ts
@@ -267,8 +267,8 @@ describe('max tick cross spec', () => {
       targetSqrtPrice
     )
     const poolAfter = await getPool(invariant, poolKey)
-    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
-    expect(crosses).toBe(1708n)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -searchLimit
+    expect(crosses).toBe(6n)
     expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountIn, positions between search limit range', async () => {
@@ -312,8 +312,8 @@ describe('max tick cross spec', () => {
     )
 
     const poolAfter = await getPool(invariant, poolKey)
-    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
-    expect(crosses).toBe(2047n)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / searchLimit
+    expect(crosses).toBe(7n)
     expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap xToY and ByAmountOut, no liquidity gap between positions', async () => {
@@ -586,8 +586,8 @@ describe('max tick cross spec', () => {
       mintAmount
     )
     const poolAfter = await getPool(invariant, poolKey)
-    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -10n
-    expect(crosses).toBe(1858n)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / -searchLimit
+    expect(crosses).toBe(7n)
     expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
   test('max tick cross swap yToX and ByAmountOut, positions between search limit range', async () => {
@@ -640,8 +640,8 @@ describe('max tick cross spec', () => {
     )
 
     const poolAfter = await getPool(invariant, poolKey)
-    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / 10n
-    expect(crosses).toBe(2047n)
+    const crosses = (poolAfter.currentTickIndex - poolBefore.currentTickIndex) / searchLimit
+    expect(crosses).toBe(7n)
     expect(gasAmount).toBeLessThan(txGasLimit)
   }, 100000)
 })

--- a/test/max_tick_cross.test.ts
+++ b/test/max_tick_cross.test.ts
@@ -43,12 +43,12 @@ describe('max tick cross spec', () => {
     const poolKey = await newPoolKey(tokenX.contractId, tokenY.contractId, feeTier)
     const liquidityDelta = 10000000n * 10n ** LiquidityScale
 
-    const lastTick = -250n
+    const lastInitializedTick = -250n
     const amount = 40300n
     // 40.3k - 8
     // 40.4k - out of gas
 
-    for (let i = lastTick; i < 0n; i += 10n) {
+    for (let i = lastInitializedTick; i < 0n; i += 10n) {
       const positionOwnerBalanceX = await balanceOf(tokenX.contractId, positionOwner.address)
       const positionOwnerBalanceY = await balanceOf(tokenY.contractId, positionOwner.address)
       const { sqrtPrice: slippageLimit } = await getPool(invariant, poolKey)


### PR DESCRIPTION
In optimistic case the max crosses vary between 7 and 9 crosses, while on 9 crosses the transaction is using 4.95m gas out of 5m available. 
In pessimistic scenario, swap can cross  7 ticks

In all of the cases direction of the swap or specifying input or output parameter does not have significant influence on cross limit