### PR TITLE
Migrate to new version of uints

### DIFF
--- a/contracts/math/clamm.ral
+++ b/contracts/math/clamm.ral
@@ -307,13 +307,6 @@ Contract CLAMM(admin: Address) extends Uints(), Log(){
         assert!(tickIndex <= maxTick, CLAMMError.InvalidTickIndex)
         assert!(tickIndex >= minTick, CLAMMError.InvalidTickIndex)
     }
-    
-    fn calculateMinAmountOut(
-        expectedAmountOut: TokenAmount,
-        slippage: Percentage
-    ) -> TokenAmount {
-        return TokenAmount{v: toU256(bigMulDivUp256(expectedAmountOut.v, (PERCENTAGE_DENOMINATOR - slippage.v), PERCENTAGE_DENOMINATOR))}
-    }
 
     pub fn checkTickToSqrtPriceRelationship(tickIndex: I256, tickSpacing: U256, sqrtPrice: SqrtPrice) -> Bool {
         if (tickIndex + toI256!(tickSpacing) > GLOBAL_MAX_TICK) {

--- a/contracts/math/uints.ral
+++ b/contracts/math/uints.ral
@@ -19,35 +19,16 @@ Abstract Contract Uints () {
     }
 
     fn bigAdd256(a: U256, b: U256) -> U512 {
-        let (lower, overflow) = overflowingAdd(a, b)
-        
-        if(overflow == 1) {
-            return U512 { higher: 1, lower: lower }
-        }
-
-        return U512 { higher: 0, lower: lower }
-    }
-
-    fn newBigAdd256(a: U256, b: U256) -> U512 {
         let lower = a |+| b
 
         if (lower < b) {
-            return U512 { higher: 1, lower: lower }
+            return U512 { higher: 1, lower }
         }
 
-        return U512 { higher: 0, lower: lower }
+        return U512 { higher: 0, lower }
     }
 
     fn bigAdd(a: U512, b: U256) -> U512 {
-        let (lower, lowerOverflow) = overflowingAdd(a.lower, b)
-        let (higher, higherOverflow) = overflowingAdd(a.higher, lowerOverflow)
-
-        assert!(higherOverflow == 0, ArithmeticError.AddOverflow)
-
-        return U512 { higher: higher, lower: lower }
-    }
-
-    fn newBigAdd(a: U512, b: U256) -> U512 {
         let lower = a.lower |+| b
         let mut higher = a.higher
 
@@ -55,20 +36,10 @@ Abstract Contract Uints () {
             higher = higher + 1
         }
 
-        return U512 { higher: higher, lower: lower }
+        return U512 { higher, lower }
     }
 
     fn bigAdd512(a: U512, b: U512) -> U512 {
-        let (lower, lowerOverflow) = overflowingAdd(a.lower, b.lower)
-        let (higherIntermediate, higherIntermediateOverflow) = overflowingAdd(a.higher, b.higher)
-        let (higher, higherOverflow) = overflowingAdd(higherIntermediate, lowerOverflow)
-
-        assert!(higherIntermediateOverflow != 1 && higherOverflow != 1, ArithmeticError.AddOverflow)
-
-        return U512 { higher: higher, lower: lower }
-    }
-
-    fn newBigAdd512(a: U512, b: U512) -> U512 {
         let lower = a.lower |+| b.lower
         let mut higher = a.higher + b.higher
 
@@ -76,28 +47,10 @@ Abstract Contract Uints () {
             higher = higher + 1
         }
 
-        return U512 { higher: higher, lower: lower }
+        return U512 { higher, lower }
     }
 
     fn bigSub512(a: U512, b: U512) -> U512 {
-        assert!(b.higher <= a.higher, ArithmeticError.SubUnderflow)
-
-        let mut higher = a.higher - b.higher
-        let mut lower = 0
-
-        if (b.lower > a.lower) {
-            assert!(higher > 0, ArithmeticError.SubUnderflow)
-
-            higher = higher - 1
-            lower = MAX_U256 - b.lower + a.lower + 1
-        } else {
-            lower = a.lower - b.lower
-        }
-
-        return U512 { higher: higher, lower: lower }
-    }
-
-    fn newBigSub512(a: U512, b: U512) -> U512 {
         let lower = a.lower |-| b.lower
         let mut higher = a.higher - b.higher
 
@@ -105,63 +58,10 @@ Abstract Contract Uints () {
             higher = higher - 1
         }
 
-        return U512 { higher: higher, lower: lower }
+        return U512 { higher, lower }
     }
 
-    fn bigDivWrapper(a: U512, b: U256, bDenominator: U256) -> U512 {
-        assert!(b != 0, ArithmeticError.DivNotPositiveDivisor)
-        assert!(bDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
-
-        let mut q = U512 { higher: 0, lower: 0 }
-        let mut r = 0
-
-        let extA = bigMul(a, bDenominator)
-
-        if (extA.higher == 0) {
-            return U512 { higher: 0, lower: extA.lower / b }
-        }
-
-        // Optimalization case
-        if (b == MAX_U256) {
-            return U512 { higher: 0, lower: extA.higher }
-        }
-
-        if (b == 1) {
-            return extA
-        }
-
-        let mut uHigh = extA.higher
-        let mut uLow = extA.lower
-        let v = b
-
-        let mut j = 512
-        while (j > 0) {
-            j = j - 1
-            r = r << 1
-
-            if (((uHigh >> 255) & 1) != 0) {
-                r = r | 1
-            }
-            uHigh = uHigh << 1
-
-            if ((uLow >> 255) != 0) {
-                uHigh = uHigh | 1
-            }
-            uLow = uLow << 1
-            if (r >= v) {
-                r = r - v
-                if (j >= 256) {
-                    q.higher = q.higher | (1 << (j - 256))
-                } else {
-                    q.lower = q.lower | (1 << j)
-                }
-            }
-        }
-
-        return q
-    }
-
-    fn newBigDivWrapper(a: U512, b: U256) -> U512 {
+    fn bigDivWrapper(a: U512, b: U256) -> U512 {
         assert!(b != 0, ArithmeticError.DivNotPositiveDivisor)
 
         if (b == 1) {
@@ -175,41 +75,28 @@ Abstract Contract Uints () {
         let r = (0 |-| b) % b
 
         while(mutA.higher != 0) {
-            let mut mul = newBigMul256(mutA.higher, q)
-            result = newBigAdd512(result, mul)
-            mul = newBigMul256(mutA.higher, r)
-            mutA = newBigAdd512(mul, U512 { higher: 0, lower: mutA.lower })
+            let mut mul = bigMul256(mutA.higher, q)
+            result = bigAdd512(result, mul)
+            mul = bigMul256(mutA.higher, r)
+            mutA = bigAdd512(mul, U512 { higher: 0, lower: mutA.lower })
         }
 
-        result = newBigAdd512(result, U512 { higher: 0, lower: mutA.lower / b })
+        result = bigAdd512(result, U512 { higher: 0, lower: mutA.lower / b })
 
         return result
     }
 
     fn bigDiv(a: U512, b: U256, bDenominator: U256) -> U512 {
-        return bigDivWrapper(a, b, bDenominator)
-    }
-
-    fn newBigDiv(a: U512, b: U256, bDenominator: U256) -> U512 {
         assert!(bDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
-        let result = newBigMul(a, bDenominator)
-        return newBigDivWrapper(result, b)
+        let result = bigMul(a, bDenominator)
+        return bigDivWrapper(result, b)
     }
 
     fn bigDivUp(a: U512, b: U256, bDenominator: U256) -> U512 {
-        assert!(b != 0, ArithmeticError.DivNotPositiveDivisor)
         assert!(bDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
-
         let mut result = bigMul(a, bDenominator)
         result = bigAdd(result, b - 1)
-        return bigDivWrapper(result, b, 1)
-    }
-
-    fn newBigDivUp(a: U512, b: U256, bDenominator: U256) -> U512 {
-        assert!(bDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
-        let mut result = newBigMul(a, bDenominator)
-        result = newBigAdd(result, b - 1)
-        return newBigDivWrapper(result, b)
+        return bigDivWrapper(result, b)
     }
 
     fn bigDiv512(dividend: U512, divisor: U512, divisorDenominator: U256) -> U512 {
@@ -220,6 +107,12 @@ Abstract Contract Uints () {
         assert!(divisorDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
 
         let extDividend = bigMul(dividend, divisorDenominator)
+
+        // optimization for numbers < 2^256
+        if (divisor.higher == 0) {
+            return bigDivWrapper(extDividend, divisor.lower)
+        }
+
         let mut uHigh = extDividend.higher
         let mut uLow = extDividend.lower
 
@@ -262,27 +155,6 @@ Abstract Contract Uints () {
     }
 
     fn bigMul256(a: U256, b: U256) -> U512 {
-        let aLower = low128(a)
-        let aHigher = high128(a)
-        let bLower = low128(b)
-        let bHigher = high128(b)
-
-        let aLowerBLower = aLower * bLower
-        let aHigherBHigher = aHigher * bHigher
-        let aHigherBLower = aHigher * bLower
-        let aLowerBHigher = aLower * bHigher
-
-        let lowerLower = low128(aLowerBLower)
-        let lowerHigher = high128(aLowerBLower) + low128(aLowerBHigher) + low128(aHigherBLower)
-        let higherLower = low128(aHigherBHigher) + high128(aLowerBHigher) + high128(aHigherBLower)
-        let higherHigher = high128(aHigherBHigher)
-        let lower = lowerLower + (lowerHigher << 128)
-        let higher = high128(lowerHigher) + higherLower + (higherHigher << 128)
-
-        return U512 { higher: higher, lower: lower }
-    }
-
-    fn newBigMul256(a: U256, b: U256) -> U512 {
         let mulMod = mulModN!(a, b, MAX_U256)
         let lower = a |*| b
         let mut higher = mulMod |-| lower
@@ -291,21 +163,14 @@ Abstract Contract Uints () {
             higher = higher - 1
         }
 
-        return U512 { higher: higher, lower: lower }
+        return U512 { higher, lower }
     }
 
     fn bigMul(a: U512, b: U256) -> U512 {        
         let result = bigMul256(a.lower, b)
         let higher = toU256(bigMul256(a.higher, b))
 
-        return bigAdd512(result, U512 { higher: higher, lower: 0 })
-    }
-
-    fn newBigMul(a: U512, b: U256) -> U512 {        
-        let result = newBigMul256(a.lower, b)
-        let higher = toU256(newBigMul256(a.higher, b))
-
-        return newBigAdd512(result, U512 { higher: higher, lower: 0 })
+        return bigAdd512(result, U512 { higher, lower: 0 })
     }
 
     fn bigMulDiv256(a: U256, b: U256, bDenominator: U256) -> U512 {
@@ -313,15 +178,6 @@ Abstract Contract Uints () {
 
         let mut result = bigMul256(a, b)
         result = bigDiv(result, bDenominator, 1)
-
-        return result
-    }
-
-    fn newBigMulDiv256(a: U256, b: U256, bDenominator: U256) -> U512 {
-        assert!(bDenominator != 0, ArithmeticError.MulNotPositiveDenominator)
-
-        let mut result = newBigMul256(a, b)
-        result = newBigDiv(result, bDenominator, 1)
 
         return result
     }
@@ -334,34 +190,6 @@ Abstract Contract Uints () {
         result = bigDiv(result, bDenominator, 1)
 
         return result
-    }
-
-    fn newBigMulDivUp256(a: U256, b: U256, bDenominator: U256) -> U512 {
-        assert!(bDenominator != 0, ArithmeticError.MulNotPositiveDenominator)
-        let mut result = newBigMul256(a, b)
-
-        result = newBigAdd512(result, toU512(bDenominator - 1))
-        result = newBigDiv(result, bDenominator, 1)
-
-        return result
-    }
-    
-    fn overflowingAdd(a: U256, b: U256) -> (U256, U256) {
-        let lower = a |+| b
-
-        if (lower < b) {
-            return lower, 1
-        }
-
-        return lower, 0
-    }
-
-    fn low128(a: U256) -> U256 {
-        return a & ((1 << 128) - 1)
-    }
-    
-    fn high128(a: U256) -> U256 {
-        return a >> 128
     }
 
     fn bigDivToTokenUp(nominator: U512, denominator: U256) -> TokenAmount {
@@ -412,7 +240,7 @@ Abstract Contract Uints () {
             return bigMul256(fromValue, 10 ** multiplierScale)
         } else {
             let denominatorScale = fromScale - expectedScale
-            // Most likely does not require an extenstion to U512
+            // Most likely does not require an extension to U512
             return bigDiv(toU512(fromValue), 10 ** denominatorScale, 1)
         }
     }

--- a/contracts/math/uints_old.ral
+++ b/contracts/math/uints_old.ral
@@ -1,0 +1,300 @@
+Contract UintsOld () {
+    const WORD_SIZE = 256
+    
+    pub fn toU512(value: U256) -> U512 {
+        return U512 {
+            higher: 0,
+            lower: value
+        }
+    }
+
+    pub fn toU256(value: U512) -> U256 {
+        assert!(value.higher == 0, ArithmeticError.CastOverflow)
+        return value.lower
+    }
+
+    pub fn bigAdd256(a: U256, b: U256) -> U512 {
+        let (lower, overflow) = overflowingAdd(a, b)
+        
+        if(overflow == 1) {
+            return U512 { higher: 1, lower: lower }
+        }
+
+        return U512 { higher: 0, lower: lower }
+    }
+
+    pub fn bigAdd(a: U512, b: U256) -> U512 {
+        let (lower, lowerOverflow) = overflowingAdd(a.lower, b)
+        let (higher, higherOverflow) = overflowingAdd(a.higher, lowerOverflow)
+
+        assert!(higherOverflow == 0, ArithmeticError.AddOverflow)
+
+        return U512 { higher: higher, lower: lower }
+    }
+
+    pub fn bigAdd512(a: U512, b: U512) -> U512 {
+        let (lower, lowerOverflow) = overflowingAdd(a.lower, b.lower)
+        let (higherIntermediate, higherIntermediateOverflow) = overflowingAdd(a.higher, b.higher)
+        let (higher, higherOverflow) = overflowingAdd(higherIntermediate, lowerOverflow)
+
+        assert!(higherIntermediateOverflow != 1 && higherOverflow != 1, ArithmeticError.AddOverflow)
+
+        return U512 { higher: higher, lower: lower }
+    }
+
+    pub fn bigSub512(a: U512, b: U512) -> U512 {
+        assert!(b.higher <= a.higher, ArithmeticError.SubUnderflow)
+
+        let mut higher = a.higher - b.higher
+        let mut lower = 0
+
+        if (b.lower > a.lower) {
+            assert!(higher > 0, ArithmeticError.SubUnderflow)
+
+            higher = higher - 1
+            lower = MAX_U256 - b.lower + a.lower + 1
+        } else {
+            lower = a.lower - b.lower
+        }
+
+        return U512 { higher, lower }
+    }
+
+    pub fn bigDivWrapper(a: U512, b: U256, bDenominator: U256) -> U512 {
+        assert!(b != 0, ArithmeticError.DivNotPositiveDivisor)
+        assert!(bDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
+
+        let mut q = U512 { higher: 0, lower: 0 }
+        let mut r = 0
+
+        let extA = bigMul(a, bDenominator)
+
+        if (extA.higher == 0) {
+            return U512 { higher: 0, lower: extA.lower / b }
+        }
+
+        // Optimalization case
+        if (b == MAX_U256) {
+            return U512 { higher: 0, lower: extA.higher }
+        }
+
+        if (b == 1) {
+            return extA
+        }
+
+        let mut uHigh = extA.higher
+        let mut uLow = extA.lower
+        let v = b
+
+        let mut j = 512
+        while (j > 0) {
+            j = j - 1
+            r = r << 1
+
+            if (((uHigh >> 255) & 1) != 0) {
+                r = r | 1
+            }
+            uHigh = uHigh << 1
+
+            if ((uLow >> 255) != 0) {
+                uHigh = uHigh | 1
+            }
+            uLow = uLow << 1
+            if (r >= v) {
+                r = r - v
+                if (j >= 256) {
+                    q.higher = q.higher | (1 << (j - 256))
+                } else {
+                    q.lower = q.lower | (1 << j)
+                }
+            }
+        }
+
+        return q
+    }
+
+    pub fn bigDiv(a: U512, b: U256, bDenominator: U256) -> U512 {
+        return bigDivWrapper(a, b, bDenominator)
+    }
+
+    pub fn bigDivUp(a: U512, b: U256, bDenominator: U256) -> U512 {
+        assert!(b != 0, ArithmeticError.DivNotPositiveDivisor)
+        assert!(bDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
+
+        let mut result = bigMul(a, bDenominator)
+        result = bigAdd(result, b - 1)
+        return bigDivWrapper(result, b, 1)
+    }
+
+    pub fn bigDiv512(dividend: U512, divisor: U512, divisorDenominator: U256) -> U512 {
+        let mut q = U512 { higher: 0, lower: 0 }
+        let mut r = U512 { higher: 0, lower: 0 }
+
+        assert!(!isZero(divisor), ArithmeticError.DivNotPositiveDivisor)
+        assert!(divisorDenominator != 0, ArithmeticError.DivNotPositiveDenominator)
+
+        let extDividend = bigMul(dividend, divisorDenominator)
+        let mut uHigh = extDividend.higher
+        let mut uLow = extDividend.lower
+
+        let v = divisor
+    
+        let mut j = 512
+        while (j > 0) {
+            j = j - 1
+            r = bigShl(r, 1)
+    
+            if (((uHigh >> 255) & 1) != 0) {
+                r = bitOrLower(r, 1)
+            }
+
+            uHigh = uHigh << 1
+    
+            if ((uLow >> 255) != 0) {
+                uHigh = uHigh | 1
+            }
+            uLow = uLow << 1
+    
+            if (isGreaterEqual(r,v)) {
+                r = bigSub512(r, v)
+                if (j >= 256) {
+                    q.higher = q.higher | (1 << (j - 256))
+                } else {
+                    q.lower = q.lower | (1 << j)
+                }
+            }
+        }
+
+        return q
+    }
+
+    pub fn bigDivUp512(dividend: U512, divisor: U512, divisorDenominator: U256) -> U512 {
+        let mut result = bigMul(dividend, divisorDenominator)
+        result = bigAdd512(result, divisor)
+        result.lower = result.lower - 1
+        return bigDiv512(result, divisor, 1)
+    }
+
+    pub fn bigMul256(a: U256, b: U256) -> U512 {
+        let aLower = low128(a)
+        let aHigher = high128(a)
+        let bLower = low128(b)
+        let bHigher = high128(b)
+
+        let aLowerBLower = aLower * bLower
+        let aHigherBHigher = aHigher * bHigher
+        let aHigherBLower = aHigher * bLower
+        let aLowerBHigher = aLower * bHigher
+
+        let lowerLower = low128(aLowerBLower)
+        let lowerHigher = high128(aLowerBLower) + low128(aLowerBHigher) + low128(aHigherBLower)
+        let higherLower = low128(aHigherBHigher) + high128(aLowerBHigher) + high128(aHigherBLower)
+        let higherHigher = high128(aHigherBHigher)
+        let lower = lowerLower + (lowerHigher << 128)
+        let higher = high128(lowerHigher) + higherLower + (higherHigher << 128)
+
+        return U512 { higher: higher, lower: lower }
+    }
+
+    pub fn bigMul(a: U512, b: U256) -> U512 {        
+        let result = bigMul256(a.lower, b)
+        let higher = toU256(bigMul256(a.higher, b))
+
+        return bigAdd512(result, U512 { higher: higher, lower: 0 })
+    }
+
+    pub fn bigMulDiv256(a: U256, b: U256, bDenominator: U256) -> U512 {
+        assert!(bDenominator != 0, ArithmeticError.MulNotPositiveDenominator)
+
+        let mut result = bigMul256(a, b)
+        result = bigDiv(result, bDenominator, 1)
+
+        return result
+    }
+
+    pub fn bigMulDivUp256(a: U256, b: U256, bDenominator: U256) -> U512 {
+        assert!(bDenominator != 0, ArithmeticError.MulNotPositiveDenominator)
+        let mut result = bigMul256(a, b)
+
+        result = bigAdd512(result, toU512(bDenominator - 1))
+        result = bigDiv(result, bDenominator, 1)
+
+        return result
+    }
+    
+    pub fn overflowingAdd(a: U256, b: U256) -> (U256, U256) {
+        let lower = a |+| b
+
+        if (lower < b) {
+            return lower, 1
+        }
+
+        return lower, 0
+    }
+
+    pub fn low128(a: U256) -> U256 {
+        return a & ((1 << 128) - 1)
+    }
+    
+    pub fn high128(a: U256) -> U256 {
+        return a >> 128
+    }
+
+    pub fn bigDivToTokenUp(nominator: U512, denominator: U256) -> TokenAmount {
+        let mut result = bigMul(nominator, SQRT_PRICE_DENOMINATOR)
+        result = bigAdd(result, denominator - 1)
+        result = bigDiv(result, denominator, 1)
+        result = bigAdd(result, SQRT_PRICE_DENOMINATOR - 1)
+        result = bigDiv(result, SQRT_PRICE_DENOMINATOR, 1)
+
+        return TokenAmount{v: toU256(result)}
+    }
+
+    pub fn bigDivToToken(nominator: U512, denominator: U256) -> TokenAmount {
+        let mut result = bigMul(nominator, SQRT_PRICE_DENOMINATOR)
+        result = bigDiv(result, denominator, 1)
+        result = bigDiv(result, SQRT_PRICE_DENOMINATOR, 1)
+
+        return TokenAmount{v: toU256(result)}
+    }
+
+    pub fn isGreaterEqual(v: U512, compareTo: U512) -> Bool {
+        if (v.higher > compareTo.higher || (v.higher == compareTo.higher && v.lower >= compareTo.lower)) {
+            return true
+        }
+
+        return false
+    }
+
+    pub fn bigShl(mut v: U512, n: U256) -> U512 {
+        if (n >= WORD_SIZE) {
+            v.higher = v.lower << (n - WORD_SIZE)
+            v.lower = 0
+        } else {
+            v.higher = (v.higher << n) | (v.lower >> (WORD_SIZE - n))
+            v.lower = v.lower << n
+        }
+        
+        return v
+    }
+
+    pub fn bitOrLower(v: U512, n: U256) -> U512 {
+        return U512 { higher: v.higher, lower: v.lower | n }
+    }
+    
+    pub fn bigRescale(fromValue: U256, fromScale: U256, expectedScale: U256) -> U512 {
+        if (expectedScale > fromScale) {
+            let multiplierScale = expectedScale - fromScale
+            return bigMul256(fromValue, 10 ** multiplierScale)
+        } else {
+            let denominatorScale = fromScale - expectedScale
+            // Most likely does not require an extenstion to U512
+            return bigDiv(toU512(fromValue), 10 ** denominatorScale, 1)
+        }
+    }
+
+    pub fn isZero(a: U512) -> Bool {
+        return a.higher == 0 && a.lower == 0
+    }
+}
+

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -606,18 +606,6 @@ export const getNextSqrtPriceYDown = async (
   ).returns.v as SqrtPrice
 }
 
-export const calculateMinAmountOut = async (
-  clamm: CLAMMInstance,
-  expectedAmountOut: TokenAmount,
-  slippage: Percentage
-): Promise<TokenAmount> => {
-  return (
-    await clamm.view.calculateMinAmountOut({
-      args: { expectedAmountOut: { v: expectedAmountOut }, slippage: { v: slippage } }
-    })
-  ).returns.v as TokenAmount
-}
-
 export const isEnoughAmountToChangePrice = async (
   clamm: CLAMMInstance,
   amount: TokenAmount,

--- a/test/contract/unit/clamm.test.ts
+++ b/test/contract/unit/clamm.test.ts
@@ -7,7 +7,6 @@ import {
   calculateAmountDelta,
   calculateFeeGrowthInside,
   calculateMaxLiquidityPerTick,
-  calculateMinAmountOut,
   calculateSqrtPrice,
   computeSwapStep,
   expectError,
@@ -1063,118 +1062,6 @@ describe('clamm tests', () => {
     )
   })
 
-  test('calculate min amount out', async () => {
-    const clamm = await deployCLAMM(sender)
-    // 0% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = 0n as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(100n)
-    }
-    // 0.1% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (10n ** 9n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(100n)
-    }
-    // 0.9% fee
-    {
-      const expectedAmountOut = 123n as TokenAmount
-      const slippage = (9n * 10n ** 9n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(122n)
-    }
-    // 1% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (10n ** 10n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(99n)
-    }
-    // 3% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (3n * 10n ** 10n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(97n)
-    }
-    // 5% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (5n * 10n ** 10n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(95n)
-    }
-    // 10% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (10n ** 11n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(90n)
-    }
-    // 20% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (2n * 10n ** 11n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(80n)
-    }
-    // 50% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (5n * 10n ** 11n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(50n)
-    }
-    // 100% fee
-    {
-      const expectedAmountOut = 100n as TokenAmount
-      const slippage = (10n ** 12n) as Percentage
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(0n)
-    }
-  })
-
-  test('calculate min amount out - domain', async () => {
-    const clamm = await deployCLAMM(sender)
-    const minAmount = 0n as TokenAmount
-    const maxAmount = ((1n << 256n) - 1n) as TokenAmount
-    const minFee = 0n as Percentage
-    const maxFee = (10n ** 12n) as Percentage
-    // min amount min fee
-    {
-      const expectedAmountOut = minAmount
-      const slippage = minFee
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(0n)
-    }
-    // min amount max fee
-    {
-      const expectedAmountOut = minAmount
-      const slippage = maxFee
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-      expect(result).toEqual(0n)
-    }
-    // max amount max fee
-    {
-      const expectedAmountOut = maxAmount
-      const slippage = maxFee
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-
-      expect(result).toEqual(0n)
-    }
-    // max amount min fee
-    {
-      const expectedAmountOut = maxAmount
-      const slippage = minFee
-      const result = await calculateMinAmountOut(clamm, expectedAmountOut, slippage)
-
-      expect(result).toEqual(maxAmount)
-    }
-  })
-
   test('is enough amount to change price - domain', async () => {
     const clamm = await deployCLAMM(sender)
     const zeroLiquidity = 0n as Liquidity
@@ -1193,8 +1080,8 @@ describe('clamm tests', () => {
         byAmountIn: false,
         xToY: false
       }
-      await expectError(
-        ArithmeticError.SubUnderflow,
+      await expectVMError(
+        VMError.ArithmeticError,
         isEnoughAmountToChangePrice(
           clamm,
           params.amount,
@@ -1203,8 +1090,7 @@ describe('clamm tests', () => {
           params.fee,
           params.byAmountIn,
           params.xToY
-        ),
-        clamm
+        )
       )
     }
     // L = 0
@@ -1238,8 +1124,8 @@ describe('clamm tests', () => {
         byAmountIn: false,
         xToY: false
       }
-      await expectError(
-        ArithmeticError.SubUnderflow,
+      await expectVMError(
+        VMError.ArithmeticError,
         isEnoughAmountToChangePrice(
           clamm,
           params.amount,
@@ -1248,8 +1134,7 @@ describe('clamm tests', () => {
           params.fee,
           params.byAmountIn,
           params.xToY
-        ),
-        clamm
+        )
       )
     }
     // Max amount
@@ -1261,8 +1146,8 @@ describe('clamm tests', () => {
       byAmountIn: false,
       xToY: false
     }
-    await expectError(
-      ArithmeticError.SubUnderflow,
+    await expectVMError(
+      VMError.ArithmeticError,
       isEnoughAmountToChangePrice(
         clamm,
         params.amount,
@@ -1271,8 +1156,7 @@ describe('clamm tests', () => {
         params.fee,
         params.byAmountIn,
         params.xToY
-      ),
-      clamm
+      )
     )
   })
 
@@ -1954,16 +1838,15 @@ describe('clamm tests', () => {
         x: maxX,
         addX: false
       }
-      await expectError(
-        ArithmeticError.SubUnderflow,
+      await expectVMError(
+        VMError.ArithmeticError,
         getNextSqrtPriceXUp(
           clamm,
           params.startingSqrtPrice,
           params.liquidity,
           params.x,
           params.addX
-        ),
-        clamm
+        )
       )
     })
 
@@ -2211,16 +2094,15 @@ describe('clamm tests', () => {
         amount: maxAmount,
         xToY: false
       }
-      await expectError(
-        ArithmeticError.SubUnderflow,
+      await expectVMError(
+        VMError.ArithmeticError,
         getNextSqrtPriceFromOutput(
           clamm,
           params.startingSqrtPrice,
           params.liquidity,
           params.amount,
           params.xToY
-        ),
-        clamm
+        )
       )
     })
   })

--- a/test/contract/unit/uints.test.ts
+++ b/test/contract/unit/uints.test.ts
@@ -2,35 +2,49 @@ import { ONE_ALPH, SignerProvider, web3 } from '@alephium/web3'
 import { getSigner } from '@alephium/web3-test'
 import { expectError, expectVMError } from '../../../src/testUtils'
 import { ArithmeticError, MAX_U256, VMError } from '../../../src/consts'
-import { CLAMMInstance } from '../../../artifacts/ts'
+import { CLAMMInstance, UintsOld, UintsOldInstance } from '../../../artifacts/ts'
 import { deployCLAMM } from '../../../src/testUtils'
+import { waitTxConfirmed } from '../../../src/utils'
 
 web3.setCurrentNodeProvider('http://127.0.0.1:22973')
 
+export async function deployUintsOld(signer: SignerProvider): Promise<UintsOldInstance> {
+  const { address } = await signer.getSelectedAccount()
+  const deployResult = await waitTxConfirmed(
+    UintsOld.deploy(signer, {
+      initialFields: { admin: address },
+      exposePrivateFunctions: true
+    })
+  )
+  return UintsOld.at(deployResult.contractInstance.address)
+}
+
 describe('uints tests', () => {
   let sender: SignerProvider
-  let clamm: CLAMMInstance
+  let uints: CLAMMInstance
+  let uintsOld: UintsOldInstance
 
   beforeAll(async () => {
     sender = await getSigner(ONE_ALPH * 100000n, 0)
-    clamm = await deployCLAMM(sender)
+    uints = await deployCLAMM(sender)
+    uintsOld = await deployUintsOld(sender)
   })
 
   test('to u256', async () => {
     const value = { higher: 0n, lower: 1n }
-    const result = (await clamm.view.toU256({ args: { value } })).returns
+    const result = (await uints.view.toU256({ args: { value } })).returns
 
     expect(result).toEqual(value.lower)
   })
 
   test('to u256 returns an error if number is higher than u256', async () => {
     const value = { higher: 2n, lower: 1n }
-    await expectError(ArithmeticError.CastOverflow, clamm.view.toU256({ args: { value } }), clamm)
+    await expectError(ArithmeticError.CastOverflow, uints.view.toU256({ args: { value } }), uints)
   })
 
   test('to u512', async () => {
     const value = 1n
-    const result = (await clamm.view.toU512({ args: { value } })).returns
+    const result = (await uints.view.toU512({ args: { value } })).returns
     expect(result).toEqual({ higher: 0n, lower: value })
   })
 
@@ -42,7 +56,7 @@ describe('uints tests', () => {
       }
       const b = { higher: 0n, lower: 10n ** 5n }
       const result = (
-        await clamm.view.bigDiv512({ args: { dividend: a, divisor: b, divisorDenominator: 1n } })
+        await uints.view.bigDiv512({ args: { dividend: a, divisor: b, divisorDenominator: 1n } })
       ).returns
       expect(result).toStrictEqual({
         higher: 655353839192537149999999n,
@@ -56,7 +70,7 @@ describe('uints tests', () => {
       }
       const b = { higher: 1n, lower: 0n }
       const result = (
-        await clamm.view.bigDiv512({ args: { dividend: a, divisor: b, divisorDenominator: 1n } })
+        await uints.view.bigDiv512({ args: { dividend: a, divisor: b, divisorDenominator: 1n } })
       ).returns
       expect(result).toStrictEqual({
         higher: 0n,
@@ -70,7 +84,7 @@ describe('uints tests', () => {
       }
       const b = { higher: MAX_U256, lower: MAX_U256 }
       const result = (
-        await clamm.view.bigDiv512({ args: { dividend: a, divisor: b, divisorDenominator: 1n } })
+        await uints.view.bigDiv512({ args: { dividend: a, divisor: b, divisorDenominator: 1n } })
       ).returns
       expect(result).toStrictEqual({
         higher: 0n,
@@ -83,25 +97,25 @@ describe('uints tests', () => {
     {
       const v = { higher: 0n, lower: 1n }
       const n = 1n
-      const result = (await clamm.view.bigShl({ args: { v, n } })).returns
+      const result = (await uints.view.bigShl({ args: { v, n } })).returns
       expect(result).toEqual({ higher: 0n, lower: 2n })
     }
     {
       const v = { higher: 0n, lower: 1n }
       const n = 257n
-      const result = (await clamm.view.bigShl({ args: { v, n } })).returns
+      const result = (await uints.view.bigShl({ args: { v, n } })).returns
       expect(result).toEqual({ higher: 2n, lower: 0n })
     }
     {
       const v = { higher: 1n, lower: 4n }
       const n = 1n
-      const result = (await clamm.view.bigShl({ args: { v, n } })).returns
+      const result = (await uints.view.bigShl({ args: { v, n } })).returns
       expect(result).toEqual({ higher: 2n, lower: 8n })
     }
     {
       const v = { higher: MAX_U256, lower: MAX_U256 }
       const n = 1n
-      const result = (await clamm.view.bigShl({ args: { v, n } })).returns
+      const result = (await uints.view.bigShl({ args: { v, n } })).returns
       expect(result).toEqual({ higher: MAX_U256, lower: MAX_U256 - 1n })
     }
   })
@@ -110,43 +124,43 @@ describe('uints tests', () => {
     {
       const v = { higher: 0n, lower: 1n }
       const compareTo = { higher: 0n, lower: 1n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(true)
     }
     {
       const v = { higher: 1n, lower: 1n }
       const compareTo = { higher: 1n, lower: 1n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(true)
     }
     {
       const v = { higher: 0n, lower: 1n }
       const compareTo = { higher: 1n, lower: 0n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(false)
     }
     {
       const v = { higher: 2n, lower: 3n }
       const compareTo = { higher: 2n, lower: 2n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(true)
     }
     {
       const v = { higher: 3n, lower: 1n }
       const compareTo = { higher: 0n, lower: 1n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(true)
     }
     {
       const v = { higher: 3n, lower: 0n }
       const compareTo = { higher: 3n, lower: 0n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(true)
     }
     {
       const v = { higher: 3n, lower: 0n }
       const compareTo = { higher: 3n, lower: 1n }
-      const result = (await clamm.view.isGreaterEqual({ args: { v, compareTo } })).returns
+      const result = (await uints.view.isGreaterEqual({ args: { v, compareTo } })).returns
       expect(result).toEqual(false)
     }
   })
@@ -155,51 +169,30 @@ describe('uints tests', () => {
     {
       const a = 1n
       const b = 2n
-      const result = (await clamm.view.bigAdd256({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 3n })
     }
     {
       const a = MAX_U256
       const b = 2n
-      const result = (await clamm.view.bigAdd256({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: 1n })
     }
     {
       const a = MAX_U256
       const b = MAX_U256
-      const result = (await clamm.view.bigAdd256({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: a - 1n })
     }
   })
 
-  test('new big add 256', async () => {
-    {
-      const a = 1n
-      const b = 2n
-      const result = (await clamm.view.newBigAdd256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 3n })
-    }
-    {
-      const a = MAX_U256
-      const b = 2n
-      const result = (await clamm.view.newBigAdd256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: 1n })
-    }
+  test('old big add 256 vs big add 256 comparison', async () => {
     {
       const a = MAX_U256
       const b = MAX_U256
-      const result = (await clamm.view.newBigAdd256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: a - 1n })
-    }
-  })
-
-  test('big add 256 vs new big add 256 comparison', async () => {
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const oldResult = await clamm.view.bigAdd256({ args: { a, b } })
-      const newResult = await clamm.view.newBigAdd256({ args: { a, b } })
-      console.log('big add 256', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigAdd256({ args: { a, b } })
+      const newResult = await uints.view.bigAdd256({ args: { a, b } })
+      console.log('big add 256:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -207,25 +200,25 @@ describe('uints tests', () => {
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
-      const result = (await clamm.view.bigAdd({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 3n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = 2n
-      const result = (await clamm.view.bigAdd({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: 1n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = MAX_U256
-      const result = (await clamm.view.bigAdd({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: a.lower - 1n })
     }
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = MAX_U256
-      const result = (await clamm.view.bigAdd({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual({
         higher: MAX_U256,
         lower: MAX_U256
@@ -233,43 +226,13 @@ describe('uints tests', () => {
     }
   })
 
-  test('new big add', async () => {
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const result = (await clamm.view.newBigAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 3n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = 2n
-      const result = (await clamm.view.newBigAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: 1n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = MAX_U256
-      const result = (await clamm.view.newBigAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: a.lower - 1n })
-    }
+  test('old big add vs big add comparison', async () => {
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = MAX_U256
-      const result = (await clamm.view.newBigAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual({
-        higher: MAX_U256,
-        lower: MAX_U256
-      })
-    }
-  })
-
-  test('big add vs new big add comparison', async () => {
-    {
-      const a = { higher: MAX_U256, lower: 0n }
-      const b = MAX_U256
-      const oldResult = await clamm.view.bigAdd({ args: { a, b } })
-      const newResult = await clamm.view.newBigAdd({ args: { a, b } })
-      console.log('big add', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigAdd({ args: { a, b } })
+      const newResult = await uints.view.bigAdd({ args: { a, b } })
+      console.log('big add:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -277,115 +240,58 @@ describe('uints tests', () => {
     {
       const a = { higher: 1n, lower: 0n }
       const b = { higher: 0n, lower: 1n }
-      const result = (await clamm.view.bigSub512({ args: { a, b } })).returns
+      const result = (await uints.view.bigSub512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: MAX_U256 })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = { higher: 0n, lower: 1n }
-      const result = (await clamm.view.bigSub512({ args: { a, b } })).returns
+      const result = (await uints.view.bigSub512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = { higher: 1n, lower: 0n }
-      await expectError(
-        ArithmeticError.SubUnderflow,
-        clamm.view.bigSub512({ args: { a, b } }),
-        clamm
-      )
+      await expectVMError(VMError.ArithmeticError, uints.view.bigSub512({ args: { a, b } }))
     }
     {
       const a = { higher: 1n, lower: 0n }
       const b = { higher: 1n, lower: 0n }
-      const result = (await clamm.view.bigSub512({ args: { a, b } })).returns
+      const result = (await uints.view.bigSub512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = { higher: 1n, lower: 0n }
-      const result = (await clamm.view.bigSub512({ args: { a, b } })).returns
+      const result = (await uints.view.bigSub512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 0n })
     }
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = { higher: 0n, lower: MAX_U256 }
-      const result = (await clamm.view.bigSub512({ args: { a, b } })).returns
+      const result = (await uints.view.bigSub512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 1n })
     }
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = { higher: MAX_U256, lower: 0n }
-      const result = (await clamm.view.bigSub512({ args: { a, b } })).returns
+      const result = (await uints.view.bigSub512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = { higher: 1n, lower: 0n }
       const b = { higher: 1n, lower: 1n }
-      await expectError(
-        ArithmeticError.SubUnderflow,
-        clamm.view.bigSub512({ args: { a, b } }),
-        clamm
-      )
+      await expectVMError(VMError.ArithmeticError, uints.view.bigSub512({ args: { a, b } }))
     }
   })
 
-  test('new big sub 512', async () => {
-    {
-      const a = { higher: 1n, lower: 0n }
-      const b = { higher: 0n, lower: 1n }
-      const result = (await clamm.view.newBigSub512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: MAX_U256 })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = { higher: 0n, lower: 1n }
-      const result = (await clamm.view.newBigSub512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = { higher: 1n, lower: 0n }
-      await expectVMError(VMError.ArithmeticError, clamm.view.newBigSub512({ args: { a, b } }))
-    }
-    {
-      const a = { higher: 1n, lower: 0n }
-      const b = { higher: 1n, lower: 0n }
-      const result = (await clamm.view.newBigSub512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: MAX_U256, lower: 0n }
-      const b = { higher: 1n, lower: 0n }
-      const result = (await clamm.view.newBigSub512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 0n })
-    }
-    {
-      const a = { higher: MAX_U256, lower: 0n }
-      const b = { higher: 0n, lower: MAX_U256 }
-      const result = (await clamm.view.newBigSub512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 1n })
-    }
-    {
-      const a = { higher: MAX_U256, lower: 0n }
-      const b = { higher: MAX_U256, lower: 0n }
-      const result = (await clamm.view.newBigSub512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: 1n, lower: 0n }
-      const b = { higher: 1n, lower: 1n }
-      await expectVMError(VMError.ArithmeticError, clamm.view.newBigSub512({ args: { a, b } }))
-    }
-  })
-
-  test('big sub 512 vs new big sub 512 comparison', async () => {
+  test('old big sub 512 vs big sub 512 comparison', async () => {
     {
       const a = { higher: MAX_U256, lower: MAX_U256 }
       const b = { higher: MAX_U256, lower: MAX_U256 }
-      const oldResult = await clamm.view.bigSub512({ args: { a, b } })
-      const newResult = await clamm.view.newBigSub512({ args: { a, b } })
-      console.log('big sub 512', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigSub512({ args: { a, b } })
+      const newResult = await uints.view.bigSub512({ args: { a, b } })
+      console.log('big sub 512:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -396,7 +302,7 @@ describe('uints tests', () => {
         lower: MAX_U256
       }
       const b = 1n
-      await expectError(ArithmeticError.AddOverflow, clamm.view.bigAdd({ args: { a, b } }), clamm)
+      await expectVMError(VMError.ArithmeticError, uints.view.bigAdd({ args: { a, b } }))
     }
     {
       const a = {
@@ -404,7 +310,7 @@ describe('uints tests', () => {
         lower: 1n
       }
       const b = MAX_U256
-      await expectError(ArithmeticError.AddOverflow, clamm.view.bigAdd({ args: { a, b } }), clamm)
+      await expectVMError(VMError.ArithmeticError, uints.view.bigAdd({ args: { a, b } }))
     }
   })
 
@@ -412,19 +318,19 @@ describe('uints tests', () => {
     {
       const a = { higher: 0n, lower: 1n }
       const b = { higher: 0n, lower: 2n }
-      const result = (await clamm.view.bigAdd512({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 3n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = { higher: 0n, lower: 2n }
-      const result = (await clamm.view.bigAdd512({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: 1n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = { higher: 0n, lower: MAX_U256 }
-      const result = (await clamm.view.bigAdd512({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd512({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: a.lower - 1n })
     }
     {
@@ -433,40 +339,7 @@ describe('uints tests', () => {
         higher: MAX_U256,
         lower: 0n
       }
-      const result = (await clamm.view.bigAdd512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({
-        higher: MAX_U256,
-        lower: MAX_U256
-      })
-    }
-  })
-
-  test('new big add 512', async () => {
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = { higher: 0n, lower: 2n }
-      const result = (await clamm.view.newBigAdd512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 3n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = { higher: 0n, lower: 2n }
-      const result = (await clamm.view.newBigAdd512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: 1n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = { higher: 0n, lower: MAX_U256 }
-      const result = (await clamm.view.newBigAdd512({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: a.lower - 1n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = {
-        higher: MAX_U256,
-        lower: 0n
-      }
-      const result = (await clamm.view.newBigAdd512({ args: { a, b } })).returns
+      const result = (await uints.view.bigAdd512({ args: { a, b } })).returns
       expect(result).toStrictEqual({
         higher: MAX_U256,
         lower: MAX_U256
@@ -484,11 +357,7 @@ describe('uints tests', () => {
         higher: 0n,
         lower: 1n
       }
-      await expectError(
-        ArithmeticError.AddOverflow,
-        clamm.view.bigAdd512({ args: { a, b } }),
-        clamm
-      )
+      await expectVMError(VMError.ArithmeticError, uints.view.bigAdd512({ args: { a, b } }))
     }
     {
       const a = {
@@ -499,11 +368,7 @@ describe('uints tests', () => {
         higher: MAX_U256,
         lower: 0n
       }
-      await expectError(
-        ArithmeticError.AddOverflow,
-        clamm.view.bigAdd512({ args: { a, b } }),
-        clamm
-      )
+      await expectVMError(VMError.ArithmeticError, uints.view.bigAdd512({ args: { a, b } }))
     }
     {
       const a = {
@@ -514,57 +379,17 @@ describe('uints tests', () => {
         higher: MAX_U256,
         lower: 0n
       }
-      await expectError(
-        ArithmeticError.AddOverflow,
-        clamm.view.bigAdd512({ args: { a, b } }),
-        clamm
-      )
+      await expectVMError(VMError.ArithmeticError, uints.view.bigAdd512({ args: { a, b } }))
     }
   })
 
-  test('new big add 512 returns an error if number if higher than u512', async () => {
-    {
-      const a = {
-        higher: MAX_U256,
-        lower: MAX_U256
-      }
-      const b = {
-        higher: 0n,
-        lower: 1n
-      }
-      await expectVMError(VMError.ArithmeticError, clamm.view.newBigAdd512({ args: { a, b } }))
-    }
-    {
-      const a = {
-        higher: 1n,
-        lower: MAX_U256
-      }
-      const b = {
-        higher: MAX_U256,
-        lower: 0n
-      }
-      await expectVMError(VMError.ArithmeticError, clamm.view.newBigAdd512({ args: { a, b } }))
-    }
-    {
-      const a = {
-        higher: 1n,
-        lower: 0n
-      }
-      const b = {
-        higher: MAX_U256,
-        lower: 0n
-      }
-      await expectVMError(VMError.ArithmeticError, clamm.view.newBigAdd512({ args: { a, b } }))
-    }
-  })
-
-  test('big add 512 vs new big add 512 comparison', async () => {
+  test('old big add 512 vs big add 512 comparison', async () => {
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = { higher: 0n, lower: MAX_U256 }
-      const oldResult = await clamm.view.bigAdd512({ args: { a, b } })
-      const newResult = await clamm.view.newBigAdd512({ args: { a, b } })
-      console.log('big add 512', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigAdd512({ args: { a, b } })
+      const newResult = await uints.view.bigAdd512({ args: { a, b } })
+      console.log('big add 512:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -573,138 +398,42 @@ describe('uints tests', () => {
       const a = { higher: 0n, lower: 2n }
       const b = 1n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = { higher: 0n, lower: 2n }
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 1n })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = { higher: 1n, lower: 0n }
       const b = 1n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: 0n })
     }
     {
       const a = { higher: 20n, lower: 20n }
       const b = 10n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 2n, lower: 2n })
     }
     {
       const a = { higher: MAX_U256, lower: MAX_U256 }
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({
-        higher: 0n,
-        lower: 115792089237316195423570985008687907853269984665640564039457584007913129639935n
-      })
-    }
-    {
-      const a = { higher: MAX_U256, lower: 0n }
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({
-        higher: 0n,
-        lower: 115792089237316195423570985008687907853269984665640564039457584007913129639935n
-      })
-    }
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 10n
-      const bDenominator = 10n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const bDenominator = 10n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 5n })
-    }
-    {
-      const a = { higher: 0n, lower: 0n }
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: MAX_U256, lower: MAX_U256 }
-      const b = 1n
-      const bDenominator = 100n
-      await expectError(
-        ArithmeticError.CastOverflow,
-        clamm.view.bigDiv({ args: { a, b, bDenominator } }),
-        clamm
-      )
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.bigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-  })
-
-  test('new big div', async () => {
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 1n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 1n })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: 1n, lower: 0n }
-      const b = 1n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: 0n })
-    }
-    {
-      const a = { higher: 20n, lower: 20n }
-      const b = 10n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 2n, lower: 2n })
-    }
-    {
-      const a = { higher: MAX_U256, lower: MAX_U256 }
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({
         higher: 1n,
         lower: 1n
@@ -714,7 +443,7 @@ describe('uints tests', () => {
       const a = { higher: MAX_U256, lower: 0n }
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({
         higher: 1n,
         lower: 0n
@@ -724,21 +453,21 @@ describe('uints tests', () => {
       const a = { higher: 0n, lower: 2n }
       const b = 10n
       const bDenominator = 10n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
       const bDenominator = 10n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 5n })
     }
     {
       const a = { higher: 0n, lower: 0n }
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
@@ -747,27 +476,27 @@ describe('uints tests', () => {
       const bDenominator = 100n
       await expectError(
         ArithmeticError.CastOverflow,
-        clamm.view.newBigDiv({ args: { a, b, bDenominator } }),
-        clamm
+        uints.view.bigDiv({ args: { a, b, bDenominator } }),
+        uints
       )
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.newBigDiv({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDiv({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
   })
 
-  test('big div vs new big div comparison', async () => {
+  test('old big div vs big div comparison', async () => {
     {
       const a = { higher: MAX_U256, lower: MAX_U256 }
       const b = MAX_U256 - 1n
       const bDenominator = 1n
-      const oldResult = await clamm.view.bigDiv({ args: { a, b, bDenominator } })
-      const newResult = await clamm.view.newBigDiv({ args: { a, b, bDenominator } })
-      console.log('big div', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigDiv({ args: { a, b, bDenominator } })
+      const newResult = await uints.view.bigDiv({ args: { a, b, bDenominator } })
+      console.log('big div:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -778,8 +507,8 @@ describe('uints tests', () => {
       const bDenominator = 1n
       await expectError(
         ArithmeticError.DivNotPositiveDivisor,
-        clamm.view.newBigDiv({ args: { a, b, bDenominator } }),
-        clamm
+        uints.view.bigDiv({ args: { a, b, bDenominator } }),
+        uints
       )
     }
     {
@@ -788,31 +517,8 @@ describe('uints tests', () => {
       const bDenominator = 0n
       await expectError(
         ArithmeticError.DivNotPositiveDenominator,
-        clamm.view.newBigDiv({ args: { a, b, bDenominator } }),
-        clamm
-      )
-    }
-  })
-
-  test('new big div return error when dividing by zero or b denominator is zero', async () => {
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 0n
-      const bDenominator = 1n
-      await expectError(
-        ArithmeticError.DivNotPositiveDivisor,
-        clamm.view.bigDiv({ args: { a, b, bDenominator } }),
-        clamm
-      )
-    }
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 1n
-      const bDenominator = 0n
-      await expectError(
-        ArithmeticError.DivNotPositiveDenominator,
-        clamm.view.bigDiv({ args: { a, b, bDenominator } }),
-        clamm
+        uints.view.bigDiv({ args: { a, b, bDenominator } }),
+        uints
       )
     }
   })
@@ -822,121 +528,35 @@ describe('uints tests', () => {
       const a = { higher: 0n, lower: 2n }
       const b = 1n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = { higher: 0n, lower: 2n }
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 1n })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 1n })
     }
     {
       const a = { higher: 1n, lower: 0n }
       const b = 1n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: 0n })
     }
     {
       const a = { higher: 20n, lower: 20n }
       const b = 10n
       const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 2n, lower: 2n })
-    }
-    {
-      const a = { higher: MAX_U256, lower: MAX_U256 }
-      const b = MAX_U256
-      const bDenominator = 1n
-      await expectError(
-        ArithmeticError.AddOverflow,
-        clamm.view.bigDivUp({ args: { a, b, bDenominator } }),
-        clamm
-      )
-    }
-    {
-      const a = { higher: MAX_U256, lower: 0n }
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({
-        higher: 0n,
-        lower: 115792089237316195423570985008687907853269984665640564039457584007913129639935n
-      })
-    }
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 10n
-      const bDenominator = 10n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const bDenominator = 10n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 5n })
-    }
-    {
-      const a = { higher: 0n, lower: 0n }
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.bigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 1n })
-    }
-  })
-
-  test('new big div up', async () => {
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 1n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = { higher: 0n, lower: 2n }
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 1n })
-    }
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 1n })
-    }
-    {
-      const a = { higher: 1n, lower: 0n }
-      const b = 1n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: 0n })
-    }
-    {
-      const a = { higher: 20n, lower: 20n }
-      const b = 10n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 2n, lower: 2n })
     }
     {
@@ -945,14 +565,14 @@ describe('uints tests', () => {
       const bDenominator = 1n
       await expectVMError(
         VMError.ArithmeticError,
-        clamm.view.newBigDivUp({ args: { a, b, bDenominator } })
+        uints.view.bigDivUp({ args: { a, b, bDenominator } })
       )
     }
     {
       const a = { higher: MAX_U256, lower: 0n }
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({
         higher: 1n,
         lower: 0n
@@ -962,40 +582,40 @@ describe('uints tests', () => {
       const a = { higher: 0n, lower: 2n }
       const b = 10n
       const bDenominator = 10n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
       const bDenominator = 10n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 5n })
     }
     {
       const a = { higher: 0n, lower: 0n }
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigDivUp({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 1n })
     }
   })
 
-  test('big div up vs new big div up comparison', async () => {
+  test('old big div up vs big div up comparison', async () => {
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = MAX_U256
       const bDenominator = 1n
-      const oldResult = await clamm.view.bigDivUp({ args: { a, b, bDenominator } })
-      const newResult = await clamm.view.newBigDivUp({ args: { a, b, bDenominator } })
-      console.log('big div', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigDivUp({ args: { a, b, bDenominator } })
+      const newResult = await uints.view.bigDivUp({ args: { a, b, bDenominator } })
+      console.log('big div up:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -1004,10 +624,9 @@ describe('uints tests', () => {
       const a = { higher: 0n, lower: 2n }
       const b = 0n
       const bDenominator = 1n
-      await expectError(
-        ArithmeticError.DivNotPositiveDivisor,
-        clamm.view.bigDivUp({ args: { a, b, bDenominator } }),
-        clamm
+      await expectVMError(
+        VMError.ArithmeticError,
+        uints.view.bigDivUp({ args: { a, b, bDenominator } })
       )
     }
     {
@@ -1016,31 +635,39 @@ describe('uints tests', () => {
       const bDenominator = 0n
       await expectError(
         ArithmeticError.DivNotPositiveDenominator,
-        clamm.view.bigDivUp({ args: { a, b, bDenominator } }),
-        clamm
+        uints.view.bigDivUp({ args: { a, b, bDenominator } }),
+        uints
       )
     }
   })
 
-  test('new big div up return error when dividing by zero or b denominator is zero', async () => {
+  test('old big div 512 vs big div 512 comparison', async () => {
     {
-      const a = { higher: 0n, lower: 2n }
-      const b = 0n
-      const bDenominator = 1n
-      await expectVMError(
-        VMError.ArithmeticError,
-        clamm.view.newBigDivUp({ args: { a, b, bDenominator } })
-      )
+      const dividend = { higher: MAX_U256, lower: MAX_U256 }
+      const divisor = { higher: MAX_U256, lower: 0n }
+      const divisorDenominator = 1n
+      const oldResult = await uintsOld.view.bigDiv512({
+        args: { dividend, divisor, divisorDenominator }
+      })
+      const newResult = await uints.view.bigDiv512({
+        args: { dividend, divisor, divisorDenominator }
+      })
+      console.log('big div 512:', oldResult.gasUsed, newResult.gasUsed)
     }
+  })
+
+  test('old big div 512 up vs big div 512 up comparison', async () => {
     {
-      const a = { higher: 0n, lower: 2n }
-      const b = 1n
-      const bDenominator = 0n
-      await expectError(
-        ArithmeticError.DivNotPositiveDenominator,
-        clamm.view.newBigDivUp({ args: { a, b, bDenominator } }),
-        clamm
-      )
+      const dividend = { higher: MAX_U256 - 32n, lower: MAX_U256 }
+      const divisor = { higher: 32n, lower: 0n }
+      const divisorDenominator = 1n
+      const oldResult = await uintsOld.view.bigDivUp512({
+        args: { dividend, divisor, divisorDenominator }
+      })
+      const newResult = await uints.view.bigDivUp512({
+        args: { dividend, divisor, divisorDenominator }
+      })
+      console.log('big div up 512:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -1048,75 +675,42 @@ describe('uints tests', () => {
     {
       const a = 1n
       const b = 2n
-      const result = (await clamm.view.bigMul256({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = MAX_U256
       const b = 2n
-      const result = (await clamm.view.bigMul256({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
     }
     {
       const a = MAX_U256
       const b = MAX_U256
-      const result = (await clamm.view.bigMul256({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 1n })
     }
     {
       const a = MAX_U256
       const b = 0n
-      const result = (await clamm.view.bigMul256({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = 0n
       const b = 0n
-      const result = (await clamm.view.bigMul256({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul256({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
   })
 
-  test('new big mul 256', async () => {
-    {
-      const a = 1n
-      const b = 2n
-      const result = (await clamm.view.newBigMul256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = MAX_U256
-      const b = 2n
-      const result = (await clamm.view.newBigMul256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
-    }
+  test('old big mul 256 vs big mul 256 comparison', async () => {
     {
       const a = MAX_U256
       const b = MAX_U256
-      const result = (await clamm.view.newBigMul256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 1n })
-    }
-    {
-      const a = MAX_U256
-      const b = 0n
-      const result = (await clamm.view.newBigMul256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = 0n
-      const b = 0n
-      const result = (await clamm.view.newBigMul256({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-  })
-
-  test('big mul 256 vs new big mul 256 comparison', async () => {
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const oldResult = await clamm.view.bigMul256({ args: { a, b } })
-      const newResult = await clamm.view.newBigMul256({ args: { a, b } })
-      console.log('big mul 256', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigMul256({ args: { a, b } })
+      const newResult = await uints.view.bigMul256({ args: { a, b } })
+      console.log('big mul 256:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -1124,75 +718,42 @@ describe('uints tests', () => {
     {
       const a = { higher: 0n, lower: 1n }
       const b = 2n
-      const result = (await clamm.view.bigMul({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = 2n
-      const result = (await clamm.view.bigMul({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = MAX_U256
-      const result = (await clamm.view.bigMul({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 1n })
     }
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = 0n
-      const result = (await clamm.view.bigMul({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = { higher: 0n, lower: 0n }
       const b = 0n
-      const result = (await clamm.view.bigMul({ args: { a, b } })).returns
+      const result = (await uints.view.bigMul({ args: { a, b } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
   })
 
-  test('new big mul', async () => {
-    {
-      const a = { higher: 0n, lower: 1n }
-      const b = 2n
-      const result = (await clamm.view.newBigMul({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = 2n
-      const result = (await clamm.view.newBigMul({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
-    }
+  test('old big mul vs big mul comparison', async () => {
     {
       const a = { higher: 0n, lower: MAX_U256 }
       const b = MAX_U256
-      const result = (await clamm.view.newBigMul({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: MAX_U256 - 1n, lower: 1n })
-    }
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = 0n
-      const result = (await clamm.view.newBigMul({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = { higher: 0n, lower: 0n }
-      const b = 0n
-      const result = (await clamm.view.newBigMul({ args: { a, b } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-  })
-
-  test('big mul vs new big mul comparison', async () => {
-    {
-      const a = { higher: 0n, lower: MAX_U256 }
-      const b = MAX_U256
-      const oldResult = await clamm.view.bigMul({ args: { a, b } })
-      const newResult = await clamm.view.newBigMul({ args: { a, b } })
-      console.log('big mul', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigMul({ args: { a, b } })
+      const newResult = await uints.view.bigMul({ args: { a, b } })
+      console.log('big mul:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -1200,61 +761,22 @@ describe('uints tests', () => {
     {
       const a = { higher: MAX_U256, lower: MAX_U256 }
       const b = 2n
-      await expectError(ArithmeticError.CastOverflow, clamm.view.bigMul({ args: { a, b } }), clamm)
+      await expectError(ArithmeticError.CastOverflow, uints.view.bigMul({ args: { a, b } }), uints)
     }
     {
       const a = { higher: MAX_U256, lower: 1n }
       const b = MAX_U256
-      await expectError(ArithmeticError.CastOverflow, clamm.view.bigMul({ args: { a, b } }), clamm)
+      await expectError(ArithmeticError.CastOverflow, uints.view.bigMul({ args: { a, b } }), uints)
     }
     {
       const a = { higher: MAX_U256 - 1n, lower: MAX_U256 }
       const b = MAX_U256
-      await expectError(ArithmeticError.CastOverflow, clamm.view.bigMul({ args: { a, b } }), clamm)
+      await expectError(ArithmeticError.CastOverflow, uints.view.bigMul({ args: { a, b } }), uints)
     }
     {
       const a = { higher: MAX_U256, lower: MAX_U256 }
       const b = MAX_U256
-      await expectError(ArithmeticError.CastOverflow, clamm.view.bigMul({ args: { a, b } }), clamm)
-    }
-  })
-
-  test('new big mul returns an error if number is higher than u512', async () => {
-    {
-      const a = { higher: MAX_U256, lower: MAX_U256 }
-      const b = 2n
-      await expectError(
-        ArithmeticError.CastOverflow,
-        clamm.view.newBigMul({ args: { a, b } }),
-        clamm
-      )
-    }
-    {
-      const a = { higher: MAX_U256, lower: 1n }
-      const b = MAX_U256
-      await expectError(
-        ArithmeticError.CastOverflow,
-        clamm.view.newBigMul({ args: { a, b } }),
-        clamm
-      )
-    }
-    {
-      const a = { higher: MAX_U256 - 1n, lower: MAX_U256 }
-      const b = MAX_U256
-      await expectError(
-        ArithmeticError.CastOverflow,
-        clamm.view.newBigMul({ args: { a, b } }),
-        clamm
-      )
-    }
-    {
-      const a = { higher: MAX_U256, lower: MAX_U256 }
-      const b = MAX_U256
-      await expectError(
-        ArithmeticError.CastOverflow,
-        clamm.view.newBigMul({ args: { a, b } }),
-        clamm
-      )
+      await expectError(ArithmeticError.CastOverflow, uints.view.bigMul({ args: { a, b } }), uints)
     }
   })
 
@@ -1263,21 +785,21 @@ describe('uints tests', () => {
       const a = 1n
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = MAX_U256
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
     }
     {
       const a = MAX_U256
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({
         higher: MAX_U256 - 1n,
         lower: 1n
@@ -1287,109 +809,47 @@ describe('uints tests', () => {
       const a = MAX_U256
       const b = 0n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = 0n
       const b = 0n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = 100n
       const b = 200n
       const bDenominator = 100n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 200n })
     }
     {
       const a = 1n
       const b = 150n
       const bDenominator = 100n
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 1n })
     }
     {
       const a = MAX_U256
       const b = MAX_U256
       const bDenominator = MAX_U256
-      const result = (await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: MAX_U256 - 1n })
-    }
-  })
-
-  test('new big mul div 256', async () => {
-    {
-      const a = 1n
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = MAX_U256
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
-    }
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({
-        higher: MAX_U256 - 1n,
-        lower: 1n
-      })
-    }
-    {
-      const a = MAX_U256
-      const b = 0n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = 0n
-      const b = 0n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = 100n
-      const b = 200n
-      const bDenominator = 100n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 200n })
-    }
-    {
-      const a = 1n
-      const b = 150n
-      const bDenominator = 100n
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 1n })
-    }
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const bDenominator = MAX_U256
-      const result = (await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: MAX_U256 })
     }
   })
 
-  test('big mul div 256 vs new big mul div 256 comparison', async () => {
+  test('old big mul div 256 vs big mul div 256 comparison', async () => {
     {
       const a = MAX_U256
       const b = MAX_U256
       const bDenominator = 1n
-      const oldResult = await clamm.view.bigMulDiv256({ args: { a, b, bDenominator } })
-      const newResult = await clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } })
-      console.log('big mul div 256', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigMulDiv256({ args: { a, b, bDenominator } })
+      const newResult = await uints.view.bigMulDiv256({ args: { a, b, bDenominator } })
+      console.log('big mul div 256:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -1400,21 +860,8 @@ describe('uints tests', () => {
       const bDenominator = 0n
       await expectError(
         ArithmeticError.MulNotPositiveDenominator,
-        clamm.view.bigMulDiv256({ args: { a, b, bDenominator } }),
-        clamm
-      )
-    }
-  })
-
-  test('new big mul div 256 returns an error if b denominator is zero', async () => {
-    {
-      const a = 1n
-      const b = 1n
-      const bDenominator = 0n
-      await expectError(
-        ArithmeticError.MulNotPositiveDenominator,
-        clamm.view.newBigMulDiv256({ args: { a, b, bDenominator } }),
-        clamm
+        uints.view.bigMulDiv256({ args: { a, b, bDenominator } }),
+        uints
       )
     }
   })
@@ -1424,21 +871,21 @@ describe('uints tests', () => {
       const a = 1n
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = MAX_U256
       const b = 2n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
     }
     {
       const a = MAX_U256
       const b = MAX_U256
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({
         higher: MAX_U256 - 1n,
         lower: 1n
@@ -1448,100 +895,35 @@ describe('uints tests', () => {
       const a = MAX_U256
       const b = 0n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = 0n
       const b = 0n
       const bDenominator = 1n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 0n })
     }
     {
       const a = 100n
       const b = 200n
       const bDenominator = 100n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 200n })
     }
     {
       const a = 1n
       const b = 150n
       const bDenominator = 100n
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({ higher: 0n, lower: 2n })
     }
     {
       const a = MAX_U256
       const b = MAX_U256
       const bDenominator = MAX_U256
-      const result = (await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({
-        higher: 0n,
-        lower: 115792089237316195423570985008687907853269984665640564039457584007913129639934n
-      })
-    }
-  })
-
-  test('new big mul div up 256', async () => {
-    {
-      const a = 1n
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = MAX_U256
-      const b = 2n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 1n, lower: MAX_U256 - 1n })
-    }
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({
-        higher: MAX_U256 - 1n,
-        lower: 1n
-      })
-    }
-    {
-      const a = MAX_U256
-      const b = 0n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = 0n
-      const b = 0n
-      const bDenominator = 1n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 0n })
-    }
-    {
-      const a = 100n
-      const b = 200n
-      const bDenominator = 100n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 200n })
-    }
-    {
-      const a = 1n
-      const b = 150n
-      const bDenominator = 100n
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
-      expect(result).toStrictEqual({ higher: 0n, lower: 2n })
-    }
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const bDenominator = MAX_U256
-      const result = (await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })).returns
+      const result = (await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })).returns
       expect(result).toStrictEqual({
         higher: 0n,
         lower: MAX_U256
@@ -1549,14 +931,14 @@ describe('uints tests', () => {
     }
   })
 
-  test('big mul div up 256 vs new big mul div up 256 comparison', async () => {
+  test('old big mul div up 256 vs big mul div up 256 comparison', async () => {
     {
       const a = MAX_U256
       const b = MAX_U256
       const bDenominator = 1n
-      const oldResult = await clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } })
-      const newResult = await clamm.view.newBigMulDivUp256({ args: { a, b, bDenominator } })
-      console.log('big mul div up 256', oldResult.gasUsed, newResult.gasUsed)
+      const oldResult = await uintsOld.view.bigMulDivUp256({ args: { a, b, bDenominator } })
+      const newResult = await uints.view.bigMulDivUp256({ args: { a, b, bDenominator } })
+      console.log('big mul div up 256:', oldResult.gasUsed, newResult.gasUsed)
     }
   })
 
@@ -1567,55 +949,9 @@ describe('uints tests', () => {
       const bDenominator = 0n
       await expectError(
         ArithmeticError.MulNotPositiveDenominator,
-        clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } }),
-        clamm
+        uints.view.bigMulDivUp256({ args: { a, b, bDenominator } }),
+        uints
       )
-    }
-  })
-
-  test('new big mul div up 256 returns an error if b denominator is zero', async () => {
-    {
-      const a = 1n
-      const b = 1n
-      const bDenominator = 0n
-      await expectError(
-        ArithmeticError.MulNotPositiveDenominator,
-        clamm.view.bigMulDivUp256({ args: { a, b, bDenominator } }),
-        clamm
-      )
-    }
-  })
-
-  test('overflowing add', async () => {
-    {
-      const a = 1n
-      const b = 2n
-      const result = (await clamm.view.overflowingAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual([3n, 0n])
-    }
-    {
-      const a = MAX_U256
-      const b = 2n
-      const result = (await clamm.view.overflowingAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual([1n, 1n])
-    }
-    {
-      const a = MAX_U256
-      const b = MAX_U256
-      const result = (await clamm.view.overflowingAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual([MAX_U256 - 1n, 1n])
-    }
-    {
-      const a = MAX_U256
-      const b = 0n
-      const result = (await clamm.view.overflowingAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual([MAX_U256, 0n])
-    }
-    {
-      const a = MAX_U256
-      const b = 1n
-      const result = (await clamm.view.overflowingAdd({ args: { a, b } })).returns
-      expect(result).toStrictEqual([0n, 1n])
     }
   })
 
@@ -1623,31 +959,31 @@ describe('uints tests', () => {
     {
       const a = 1n
       const b = 2n
-      const result = (await clamm.view.wrappingAdd({ args: { a, b } })).returns
+      const result = (await uints.view.wrappingAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual(3n)
     }
     {
       const a = MAX_U256
       const b = 2n
-      const result = (await clamm.view.wrappingAdd({ args: { a, b } })).returns
+      const result = (await uints.view.wrappingAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual(1n)
     }
     {
       const a = MAX_U256
       const b = MAX_U256
-      const result = (await clamm.view.wrappingAdd({ args: { a, b } })).returns
+      const result = (await uints.view.wrappingAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual(MAX_U256 - 1n)
     }
     {
       const a = MAX_U256
       const b = 0n
-      const result = (await clamm.view.wrappingAdd({ args: { a, b } })).returns
+      const result = (await uints.view.wrappingAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual(MAX_U256)
     }
     {
       const a = MAX_U256
       const b = 1n
-      const result = (await clamm.view.wrappingAdd({ args: { a, b } })).returns
+      const result = (await uints.view.wrappingAdd({ args: { a, b } })).returns
       expect(result).toStrictEqual(0n)
     }
   })

--- a/test/sdk/e2e/simulate-invariant-swap.test.ts
+++ b/test/sdk/e2e/simulate-invariant-swap.test.ts
@@ -894,9 +894,9 @@ describe('simulateInvariantSwap tests', () => {
 
       // in CLAMM.isEnoughAmountToChangePrice:
       // deltaSqrtPrice < bigMulDiv256(startingSqrtPrice, x, TOKEN_AMOUNT_DENOMINATOR)
-      // subUnderflow
-      await expectError(
-        ArithmeticError.SubUnderflow,
+      // arithmetic error - subUnderflow
+      await expectVMError(
+        VMError.ArithmeticError,
         invariant.swap(swapper, poolKey, xToY, amountIn, byAmountIn, MAX_SQRT_PRICE, suppliedAmount)
       )
     })


### PR DESCRIPTION
\+ export old uint functions to a `UintsOld` contract
\+ comparison between `bigDiv512` and `bigDivUp512` versions (still should be optimized)
\+ remove unused `calculateMinAmountOut` and associated tests